### PR TITLE
Memory leak fixes

### DIFF
--- a/metrics/src/main/java/com/facebook/battery/metrics/appwakeup/AppWakeupMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/appwakeup/AppWakeupMetricsCollector.java
@@ -10,10 +10,13 @@ package com.facebook.battery.metrics.appwakeup;
 import static com.facebook.battery.metrics.appwakeup.AppWakeupMetrics.WakeupDetails;
 import static com.facebook.battery.metrics.core.Utilities.checkNotNull;
 
+import android.content.Context;
 import android.os.SystemClock;
 import com.facebook.battery.metrics.core.SystemMetricsCollector;
 import com.facebook.battery.metrics.core.SystemMetricsLogger;
 import com.facebook.infer.annotation.ThreadSafe;
+
+import javax.annotation.Nullable;
 
 /**
  * This class is used to record and aggregate the wakeups in the app. It exposes methods to record
@@ -34,7 +37,7 @@ public class AppWakeupMetricsCollector extends SystemMetricsCollector<AppWakeupM
 
   @Override
   @ThreadSafe(enableChecks = false)
-  public synchronized boolean getSnapshot(AppWakeupMetrics snapshot) {
+  public synchronized boolean getSnapshot(AppWakeupMetrics snapshot, @Nullable Context context) {
     checkNotNull(snapshot, "Null value passed to getSnapshot!");
     // TODO: Optimize by taking intersection of the two lists
     snapshot.appWakeups.clear();

--- a/metrics/src/main/java/com/facebook/battery/metrics/bluetooth/BluetoothMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/bluetooth/BluetoothMetricsCollector.java
@@ -12,12 +12,15 @@ import static com.facebook.battery.metrics.core.Utilities.checkNotNull;
 import android.app.PendingIntent;
 import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanCallback;
+import android.content.Context;
 import android.os.SystemClock;
 import android.util.SparseArray;
 import androidx.annotation.GuardedBy;
 import com.facebook.battery.metrics.core.SystemMetricsCollector;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadSafe;
+
+import javax.annotation.Nullable;
 
 /**
  * Records information about Bluetooth LE scans, meant to be used with {@link BluetoothLeScanner}.
@@ -55,7 +58,7 @@ public class BluetoothMetricsCollector extends SystemMetricsCollector<BluetoothM
   private final ScanMetrics mOpportunisticScan = new ScanMetrics();
 
   @Override
-  public synchronized boolean getSnapshot(BluetoothMetrics snapshot) {
+  public synchronized boolean getSnapshot(BluetoothMetrics snapshot, @Nullable Context context) {
     checkNotNull(snapshot, "Null value passed to getSnapshot!");
     snapshot.bleScanCount = mNonOpportunisticScan.count;
     snapshot.bleOpportunisticScanCount = mOpportunisticScan.count;

--- a/metrics/src/main/java/com/facebook/battery/metrics/camera/CameraMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/camera/CameraMetricsCollector.java
@@ -9,6 +9,7 @@ package com.facebook.battery.metrics.camera;
 
 import static com.facebook.battery.metrics.core.Utilities.checkNotNull;
 
+import android.content.Context;
 import android.hardware.Camera;
 import android.hardware.camera2.CameraCaptureSession;
 import android.hardware.camera2.CameraDevice;
@@ -21,6 +22,8 @@ import androidx.annotation.GuardedBy;
 import com.facebook.battery.metrics.core.SystemMetricsCollector;
 import com.facebook.battery.metrics.core.SystemMetricsLogger;
 import com.facebook.infer.annotation.ThreadSafe;
+
+import javax.annotation.Nullable;
 
 /**
  * CameraMetricsCollector internally maintains how long the camera was open and previewed; this is
@@ -64,7 +67,7 @@ public class CameraMetricsCollector extends SystemMetricsCollector<CameraMetrics
   public CameraMetricsCollector() {}
 
   @Override
-  public synchronized boolean getSnapshot(CameraMetrics snapshot) {
+  public synchronized boolean getSnapshot(CameraMetrics snapshot, @Nullable Context context) {
     checkNotNull(snapshot, "Null value passed to getSnapshot!");
     if (!mIsEnabled) {
       return false;

--- a/metrics/src/main/java/com/facebook/battery/metrics/composite/CompositeMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/composite/CompositeMetricsCollector.java
@@ -9,11 +9,15 @@ package com.facebook.battery.metrics.composite;
 
 import static com.facebook.battery.metrics.core.Utilities.checkNotNull;
 
+import android.content.Context;
+
 import androidx.collection.SimpleArrayMap;
 import com.facebook.battery.metrics.core.SystemMetrics;
 import com.facebook.battery.metrics.core.SystemMetricsCollector;
 import com.facebook.battery.metrics.core.VisibleToAvoidSynthetics;
 import com.facebook.infer.annotation.ThreadSafe;
+
+import javax.annotation.Nullable;
 
 /**
  * Composite metrics collector allows batching and using several Metrics Collectors together, keyed
@@ -81,11 +85,12 @@ public class CompositeMetricsCollector extends SystemMetricsCollector<CompositeM
    * collectors are expected to report any errors they might encounter.
    *
    * @param snapshot snapshot to reuse
+   * @param context
    * @return whether _any_ underlying snapshot succeeded
    */
   @Override
   @ThreadSafe(enableChecks = false)
-  public boolean getSnapshot(CompositeMetrics snapshot) {
+  public boolean getSnapshot(CompositeMetrics snapshot, @Nullable Context context) {
     checkNotNull(snapshot, "Null value passed to getSnapshot!");
     boolean result = false;
     SimpleArrayMap<Class<? extends SystemMetrics>, SystemMetrics> snapshotMetrics =
@@ -96,7 +101,7 @@ public class CompositeMetricsCollector extends SystemMetricsCollector<CompositeM
       boolean snapshotResult = false;
       if (collector != null) {
         SystemMetrics metric = snapshot.getMetric(metricsClass);
-        snapshotResult = collector.getSnapshot(metric);
+        snapshotResult = collector.getSnapshot(metric, null);
       }
       snapshot.setIsValid(metricsClass, snapshotResult);
       result |= snapshotResult;

--- a/metrics/src/main/java/com/facebook/battery/metrics/core/StatefulSystemMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/core/StatefulSystemMetricsCollector.java
@@ -29,7 +29,7 @@ import androidx.annotation.Nullable;
 public class StatefulSystemMetricsCollector<
     R extends SystemMetrics<R>, S extends SystemMetricsCollector<R>> {
 
-  private final S mCollector;
+  private S mCollector;
   private final R mDiff;
 
   private R mCurr;
@@ -44,7 +44,7 @@ public class StatefulSystemMetricsCollector<
   public StatefulSystemMetricsCollector(S collector) {
     this(
         collector, collector.createMetrics(), collector.createMetrics(), collector.createMetrics());
-    mIsValid &= collector.getSnapshot(mPrev);
+    mIsValid &= collector.getSnapshot(mPrev, null);
   }
 
   /**
@@ -82,12 +82,16 @@ public class StatefulSystemMetricsCollector<
   /** Get a diff form the previous baseline. */
   @Nullable
   public R getLatestDiff() {
-    mIsValid &= mCollector.getSnapshot(this.mCurr);
+    mIsValid &= mCollector.getSnapshot(this.mCurr, null);
     if (!mIsValid) {
       return null;
     }
 
     mCurr.diff(mPrev, mDiff);
     return mDiff;
+  }
+
+  public void clearCollectors(){
+    mCollector = null;
   }
 }

--- a/metrics/src/main/java/com/facebook/battery/metrics/core/SystemMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/core/SystemMetricsCollector.java
@@ -7,6 +7,10 @@
 
 package com.facebook.battery.metrics.core;
 
+import android.content.Context;
+
+import javax.annotation.Nullable;
+
 /**
  * Takes snapshots of a given metric. There are generally two types of metrics collectors - - those
  * that depend on an underlying api, such as the {@link
@@ -22,10 +26,11 @@ public abstract class SystemMetricsCollector<T extends SystemMetrics> {
    * by the caller requesting getSnapshot.
    *
    * @param snapshot snapshot on which the data will be written
+   * @param context
    * @return true if the snapshot has been updated with valid data.
    * @throws IllegalArgumentException if snapshot == null.
    */
-  public abstract boolean getSnapshot(T snapshot);
+  public abstract boolean getSnapshot(T snapshot, @Nullable Context context);
 
   /**
    * Creates an empty instance of the corresponding system metrics.

--- a/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuFrequencyMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuFrequencyMetricsCollector.java
@@ -9,6 +9,7 @@ package com.facebook.battery.metrics.cpu;
 
 import static com.facebook.battery.metrics.core.Utilities.checkNotNull;
 
+import android.content.Context;
 import android.util.SparseIntArray;
 import androidx.annotation.VisibleForTesting;
 import com.facebook.battery.metrics.core.ProcFileReader;
@@ -43,7 +44,7 @@ public class CpuFrequencyMetricsCollector extends SystemMetricsCollector<CpuFreq
 
   @Override
   @ThreadSafe(enableChecks = false)
-  public boolean getSnapshot(CpuFrequencyMetrics snapshot) {
+  public boolean getSnapshot(CpuFrequencyMetrics snapshot, @Nullable Context context) {
     checkNotNull(snapshot, "Null value passed to getSnapshot!");
     boolean hasAnyValid = false;
     for (int i = 0, cores = getTotalCores(); i < cores; i++) {

--- a/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuMetricsCollector.java
@@ -9,12 +9,16 @@ package com.facebook.battery.metrics.cpu;
 
 import static com.facebook.battery.metrics.core.Utilities.checkNotNull;
 
+import android.content.Context;
+
 import androidx.annotation.VisibleForTesting;
 import com.facebook.battery.metrics.core.ProcFileReader;
 import com.facebook.battery.metrics.core.SystemMetricsCollector;
 import com.facebook.battery.metrics.core.SystemMetricsLogger;
 import com.facebook.battery.metrics.core.VisibleToAvoidSynthetics;
 import com.facebook.infer.annotation.ThreadSafe;
+
+import javax.annotation.Nullable;
 
 /**
  * Collects data about cpu metrics.
@@ -44,7 +48,7 @@ public class CpuMetricsCollector extends SystemMetricsCollector<CpuMetrics> {
 
   @Override
   @ThreadSafe(enableChecks = false)
-  public boolean getSnapshot(CpuMetrics snapshot) {
+  public boolean getSnapshot(CpuMetrics snapshot, @Nullable Context context) {
     checkNotNull(snapshot, "Null value passed to getSnapshot!");
 
     try {

--- a/metrics/src/main/java/com/facebook/battery/metrics/devicebattery/DeviceBatteryMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/devicebattery/DeviceBatteryMetricsCollector.java
@@ -17,7 +17,6 @@ import android.os.BatteryManager;
 import android.os.SystemClock;
 import androidx.annotation.Nullable;
 
-import com.facebook.battery.metrics.core.DeviceBatteryMetricsInterface;
 import com.facebook.battery.metrics.core.SystemMetricsCollector;
 import com.facebook.battery.metrics.core.SystemMetricsLogger;
 import com.facebook.battery.metrics.core.VisibleToAvoidSynthetics;

--- a/metrics/src/main/java/com/facebook/battery/metrics/disk/DiskMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/disk/DiskMetricsCollector.java
@@ -9,6 +9,8 @@ package com.facebook.battery.metrics.disk;
 
 import static com.facebook.battery.metrics.core.Utilities.checkNotNull;
 
+import android.content.Context;
+
 import androidx.annotation.GuardedBy;
 import com.facebook.battery.metrics.core.ProcFileReader;
 import com.facebook.battery.metrics.core.SystemMetricsCollector;
@@ -16,6 +18,8 @@ import com.facebook.battery.metrics.core.SystemMetricsLogger;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadSafe;
 import java.nio.CharBuffer;
+
+import javax.annotation.Nullable;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
 @ThreadSafe
@@ -37,7 +41,7 @@ public class DiskMetricsCollector extends SystemMetricsCollector<DiskMetrics> {
 
   @Override
   @ThreadSafe(enableChecks = false)
-  public synchronized boolean getSnapshot(DiskMetrics snapshot) {
+  public synchronized boolean getSnapshot(DiskMetrics snapshot, @Nullable Context context) {
     checkNotNull(snapshot, "Null value passed to getSnapshot!");
     if (!mIsEnabled) {
       return false;

--- a/metrics/src/main/java/com/facebook/battery/metrics/healthstats/HealthStatsMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/healthstats/HealthStatsMetricsCollector.java
@@ -15,6 +15,8 @@ import com.facebook.battery.metrics.core.SystemMetricsCollector;
 import com.facebook.battery.metrics.core.SystemMetricsLogger;
 import com.facebook.infer.annotation.ThreadSafe;
 
+import javax.annotation.Nullable;
+
 @RequiresApi(api = Build.VERSION_CODES.N)
 @ThreadSafe(enableChecks = false)
 public class HealthStatsMetricsCollector extends SystemMetricsCollector<HealthStatsMetrics> {
@@ -30,7 +32,7 @@ public class HealthStatsMetricsCollector extends SystemMetricsCollector<HealthSt
   @Override
   @SuppressWarnings("CatchGeneralException")
   // because takeMyUidSnapshot wraps RemoteException in a RuntimeException
-  public boolean getSnapshot(HealthStatsMetrics snapshot) {
+  public boolean getSnapshot(HealthStatsMetrics snapshot, @Nullable Context context) {
     try {
       snapshot.set(mSystemHealthManager.takeMyUidSnapshot());
       return true;

--- a/metrics/src/main/java/com/facebook/battery/metrics/memory/MemoryMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/memory/MemoryMetricsCollector.java
@@ -9,6 +9,7 @@ package com.facebook.battery.metrics.memory;
 
 import static com.facebook.battery.metrics.core.Utilities.checkNotNull;
 
+import android.content.Context;
 import android.os.Debug;
 import androidx.annotation.GuardedBy;
 import com.facebook.battery.metrics.core.ProcFileReader;
@@ -17,6 +18,8 @@ import com.facebook.battery.metrics.core.SystemMetricsLogger;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadSafe;
 import java.util.concurrent.atomic.AtomicLong;
+
+import javax.annotation.Nullable;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
 @ThreadSafe
@@ -35,7 +38,7 @@ public class MemoryMetricsCollector extends SystemMetricsCollector<MemoryMetrics
 
   @Override
   @ThreadSafe(enableChecks = false)
-  public synchronized boolean getSnapshot(MemoryMetrics snapshot) {
+  public synchronized boolean getSnapshot(MemoryMetrics snapshot, @Nullable Context context) {
     checkNotNull(snapshot, "Null value passed to getSnapshot!");
     if (!mIsEnabled) {
       return false;

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/EnhancedNetworkMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/EnhancedNetworkMetricsCollector.java
@@ -15,6 +15,8 @@ import com.facebook.battery.metrics.core.SystemMetricsCollector;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadSafe;
 
+import javax.annotation.Nullable;
+
 /**
  * Alternative to {@link NetworkMetricsCollector} which supports distinguishing
  * foreground/background app states where possible (in particular when using qtaguid stats).
@@ -36,7 +38,7 @@ public class EnhancedNetworkMetricsCollector
 
   @Override
   @ThreadSafe(enableChecks = false)
-  public synchronized boolean getSnapshot(EnhancedNetworkMetrics snapshot) {
+  public synchronized boolean getSnapshot(EnhancedNetworkMetrics snapshot, @Nullable Context context) {
     if (!mIsValid || !mCollector.getTotalBytes(mBytes)) {
       return false;
     }

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/NetworkBytesCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/NetworkBytesCollector.java
@@ -29,6 +29,9 @@ abstract class NetworkBytesCollector {
 
   public abstract boolean supportsBgDistinction();
 
+  public void cleanUp(Context context){
+    //no op
+  }
   public abstract boolean getTotalBytes(@Size(8) long[] bytes);
 
   @SuppressLint("ObsoleteSdkInt")
@@ -47,4 +50,6 @@ abstract class NetworkBytesCollector {
     }
     return new TrafficStatsNetworkBytesCollector(context);
   }
+
+
 }

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/NetworkMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/NetworkMetricsCollector.java
@@ -21,6 +21,8 @@ import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadSafe;
 import java.util.Arrays;
 
+import javax.annotation.Nullable;
+
 /**
  * Records data transferred by the current application, broken down by type of network (radio vs
  * wifi) and bytes received and transmitted.
@@ -49,7 +51,7 @@ public class NetworkMetricsCollector extends SystemMetricsCollector<NetworkMetri
 
   @Override
   @ThreadSafe(enableChecks = false)
-  public synchronized boolean getSnapshot(NetworkMetrics snapshot) {
+  public synchronized boolean getSnapshot(NetworkMetrics snapshot, @Nullable Context context) {
     // Once the value has decreased, the underlying value has almost certainly reset and all current
     // snapshots are invalidated. Disable this collector.
     if (!mIsValid || !mCollector.getTotalBytes(mBytes)) {
@@ -104,5 +106,9 @@ public class NetworkMetricsCollector extends SystemMetricsCollector<NetworkMetri
   @Override
   public NetworkMetrics createMetrics() {
     return new NetworkMetrics();
+  }
+
+  public void cleanUp(Context context) {
+      mCollector.cleanUp(context);
   }
 }

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/RadioStateCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/RadioStateCollector.java
@@ -48,7 +48,7 @@ public class RadioStateCollector extends SystemMetricsCollector<RadioStateMetric
 
   @Override
   @ThreadSafe(enableChecks = false)
-  public boolean getSnapshot(RadioStateMetrics snapshot) {
+  public boolean getSnapshot(RadioStateMetrics snapshot, @javax.annotation.Nullable Context context) {
 
     final long mobileNextIdleTimeActive = mMobileRadioMonitor.mNextIdleTimeActive.get();
     snapshot.mobileHighPowerActiveS = MonotonicRadioMonitor.totalTxS(mobileNextIdleTimeActive);

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/TrafficStatsNetworkBytesCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/TrafficStatsNetworkBytesCollector.java
@@ -16,6 +16,8 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.TrafficStats;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import com.facebook.battery.metrics.core.VisibleToAvoidSynthetics;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -105,5 +107,11 @@ class TrafficStatsNetworkBytesCollector extends NetworkBytesCollector {
 
     mTotalBytes[TX | prefix] += currentTotalTxBytes - lastTotalTxBytes;
     mTotalBytes[RX | prefix] += currentTotalRxBytes - lastTotalRxBytes;
+  }
+
+  @Override
+  public void cleanUp(@NonNull Context context) {
+    super.cleanUp(context);
+    context.unregisterReceiver(mReceiver);
   }
 }

--- a/metrics/src/main/java/com/facebook/battery/metrics/sensor/SensorMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/sensor/SensorMetricsCollector.java
@@ -7,6 +7,7 @@
 
 package com.facebook.battery.metrics.sensor;
 
+import android.content.Context;
 import android.hardware.Sensor;
 import android.hardware.SensorEventListener;
 import android.os.Build;
@@ -135,7 +136,7 @@ public class SensorMetricsCollector extends SystemMetricsCollector<SensorMetrics
   }
 
   @Override
-  public synchronized boolean getSnapshot(SensorMetrics snapshot) {
+  public synchronized boolean getSnapshot(SensorMetrics snapshot, @javax.annotation.Nullable Context context) {
     Utilities.checkNotNull(snapshot, "Null value passed to getSnapshot!");
 
     if (!mEnabled) {

--- a/metrics/src/main/java/com/facebook/battery/metrics/time/TimeMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/time/TimeMetricsCollector.java
@@ -9,10 +9,13 @@ package com.facebook.battery.metrics.time;
 
 import static com.facebook.battery.metrics.core.Utilities.checkNotNull;
 
+import android.content.Context;
 import android.os.SystemClock;
 import com.facebook.battery.metrics.core.SystemMetricsCollector;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadSafe;
+
+import javax.annotation.Nullable;
 
 /**
  * Records system uptime (doesn't include time when the phone was asleep) and realtime (actual time
@@ -25,7 +28,7 @@ public class TimeMetricsCollector extends SystemMetricsCollector<TimeMetrics> {
 
   @Override
   @ThreadSafe(enableChecks = false)
-  public boolean getSnapshot(TimeMetrics snapshot) {
+  public boolean getSnapshot(TimeMetrics snapshot, @Nullable Context context) {
     checkNotNull(snapshot, "Null value passed to getSnapshot!");
     snapshot.realtimeMs = SystemClock.elapsedRealtime();
     snapshot.uptimeMs = SystemClock.uptimeMillis();

--- a/metrics/src/main/java/com/facebook/battery/metrics/wakelock/WakeLockMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/wakelock/WakeLockMetricsCollector.java
@@ -9,6 +9,7 @@ package com.facebook.battery.metrics.wakelock;
 
 import static com.facebook.battery.metrics.core.Utilities.checkNotNull;
 
+import android.content.Context;
 import android.os.PowerManager;
 import android.os.SystemClock;
 import androidx.annotation.GuardedBy;
@@ -18,6 +19,8 @@ import com.facebook.battery.metrics.core.SystemMetricsLogger;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.WeakHashMap;
+
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -180,7 +183,7 @@ public class WakeLockMetricsCollector extends SystemMetricsCollector<WakeLockMet
   }
 
   @Override
-  public synchronized boolean getSnapshot(WakeLockMetrics snapshot) {
+  public synchronized boolean getSnapshot(WakeLockMetrics snapshot, @Nullable Context context) {
     checkNotNull(snapshot, "Null value passed to getSnapshot!");
     if (!mIsEnabled) {
       return false;

--- a/metrics/src/test/java/com/facebook/battery/metrics/appwakeup/AppWakeupMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/appwakeup/AppWakeupMetricsCollectorTest.java
@@ -47,7 +47,7 @@ public class AppWakeupMetricsCollectorTest
         AppWakeupMetrics.WakeupReason.JOB_SCHEDULER, "key3");
     ShadowSystemClock.setElapsedRealtime(4);
     mAppWakeupMetricsCollector.recordWakeupStart(AppWakeupMetrics.WakeupReason.ALARM, "key4");
-    mAppWakeupMetricsCollector.getSnapshot(mAppWakeupMetrics);
+    mAppWakeupMetricsCollector.getSnapshot(mAppWakeupMetrics, null);
     assertThat(mAppWakeupMetrics.appWakeups.size()).isEqualTo(0);
 
     // Test with 2 wakeups closed and 2 open
@@ -56,7 +56,7 @@ public class AppWakeupMetricsCollectorTest
     ShadowSystemClock.setElapsedRealtime(30);
     mAppWakeupMetricsCollector.recordWakeupEnd("key3");
     ShadowSystemClock.setElapsedRealtime(35);
-    mAppWakeupMetricsCollector.getSnapshot(mAppWakeupMetrics);
+    mAppWakeupMetricsCollector.getSnapshot(mAppWakeupMetrics, null);
     assertThat(mAppWakeupMetrics.appWakeups.size()).isEqualTo(2);
     assertThat(mAppWakeupMetrics.appWakeups.get("key1"))
         .isEqualTo(new WakeupDetails(WakeupReason.ALARM, 1, 19));
@@ -71,7 +71,7 @@ public class AppWakeupMetricsCollectorTest
     ShadowSystemClock.setElapsedRealtime(57);
     mAppWakeupMetricsCollector.recordWakeupEnd("key2");
 
-    mAppWakeupMetricsCollector.getSnapshot(mAppWakeupMetrics);
+    mAppWakeupMetricsCollector.getSnapshot(mAppWakeupMetrics, null);
     assertThat(mAppWakeupMetrics.appWakeups.size()).isEqualTo(3);
     assertThat(mAppWakeupMetrics.appWakeups.get("key1"))
         .isEqualTo(new WakeupDetails(WakeupReason.ALARM, 2, 28));
@@ -85,7 +85,7 @@ public class AppWakeupMetricsCollectorTest
     mAppWakeupMetricsCollector.recordWakeupStart(AppWakeupMetrics.WakeupReason.ALARM, "key4");
     ShadowSystemClock.setElapsedRealtime(65);
     mAppWakeupMetricsCollector.recordWakeupEnd("key1");
-    mAppWakeupMetricsCollector.getSnapshot(mAppWakeupMetrics);
+    mAppWakeupMetricsCollector.getSnapshot(mAppWakeupMetrics, null);
     assertThat(mAppWakeupMetrics.appWakeups.size()).isEqualTo(3);
     assertThat(mAppWakeupMetrics.appWakeups.get("key1"))
         .isEqualTo(new WakeupDetails(WakeupReason.ALARM, 2, 28));

--- a/metrics/src/test/java/com/facebook/battery/metrics/bluetooth/BluetoothMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/bluetooth/BluetoothMetricsCollectorTest.java
@@ -39,7 +39,7 @@ public class BluetoothMetricsCollectorTest
     ScanCallback callback = mock(ScanCallback.class);
 
     // Zero at beginning
-    boolean isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics);
+    boolean isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics, null);
     assertThat(isSuccess).isTrue();
     assertThat(bluetoothMetrics.bleScanCount).isEqualTo(0);
     assertThat(bluetoothMetrics.bleScanDurationMs).isEqualTo(0);
@@ -50,7 +50,7 @@ public class BluetoothMetricsCollectorTest
 
     // Intermediate snapshot
     ShadowSystemClock.setUptimeMillis(21);
-    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics);
+    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics, null);
     assertThat(isSuccess).isTrue();
     assertThat(bluetoothMetrics.bleScanCount).isEqualTo(1);
     assertThat(bluetoothMetrics.bleScanDurationMs).isEqualTo(20);
@@ -60,14 +60,14 @@ public class BluetoothMetricsCollectorTest
     mBluetoothMetricsCollector.stopScan(callback);
 
     // Snapshot at stop
-    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics);
+    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics, null);
     assertThat(isSuccess).isTrue();
     assertThat(bluetoothMetrics.bleScanCount).isEqualTo(1);
     assertThat(bluetoothMetrics.bleScanDurationMs).isEqualTo(50);
 
     // Snapshot after stop
     ShadowSystemClock.setUptimeMillis(61);
-    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics);
+    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics, null);
     assertThat(isSuccess).isTrue();
     assertThat(bluetoothMetrics.bleScanCount).isEqualTo(1);
     assertThat(bluetoothMetrics.bleScanDurationMs).isEqualTo(50);
@@ -82,7 +82,7 @@ public class BluetoothMetricsCollectorTest
     ScanCallback callback = mock(ScanCallback.class);
 
     // Zero at beginning
-    boolean isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics);
+    boolean isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics, null);
     assertThat(isSuccess).isTrue();
     assertThat(bluetoothMetrics.bleOpportunisticScanCount).isEqualTo(0);
     assertThat(bluetoothMetrics.bleOpportunisticScanDurationMs).isEqualTo(0);
@@ -93,7 +93,7 @@ public class BluetoothMetricsCollectorTest
 
     // Intermediate snapshot
     ShadowSystemClock.setUptimeMillis(21);
-    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics);
+    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics, null);
     assertThat(isSuccess).isTrue();
     assertThat(bluetoothMetrics.bleOpportunisticScanCount).isEqualTo(1);
     assertThat(bluetoothMetrics.bleOpportunisticScanDurationMs).isEqualTo(20);
@@ -103,14 +103,14 @@ public class BluetoothMetricsCollectorTest
     mBluetoothMetricsCollector.stopScan(callback);
 
     // Snapshot at stop
-    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics);
+    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics, null);
     assertThat(isSuccess).isTrue();
     assertThat(bluetoothMetrics.bleOpportunisticScanCount).isEqualTo(1);
     assertThat(bluetoothMetrics.bleOpportunisticScanDurationMs).isEqualTo(50);
 
     // Snapshot after stop
     ShadowSystemClock.setUptimeMillis(61);
-    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics);
+    isSuccess = mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics, null);
     assertThat(isSuccess).isTrue();
     assertThat(bluetoothMetrics.bleOpportunisticScanCount).isEqualTo(1);
     assertThat(bluetoothMetrics.bleOpportunisticScanDurationMs).isEqualTo(50);
@@ -150,7 +150,7 @@ public class BluetoothMetricsCollectorTest
     mBluetoothMetricsCollector.stopScan(callbackC);
 
     // Intermediate snapshot
-    mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics);
+    mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics, null);
     assertThat(bluetoothMetrics.bleScanCount).isEqualTo(2);
     assertThat(bluetoothMetrics.bleScanDurationMs).isEqualTo(8 - 2);
     assertThat(bluetoothMetrics.bleOpportunisticScanCount).isEqualTo(1);
@@ -164,7 +164,7 @@ public class BluetoothMetricsCollectorTest
 
     // Final snapshot
     ShadowSystemClock.setUptimeMillis(64);
-    mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics);
+    mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics, null);
     assertThat(bluetoothMetrics.bleScanCount).isEqualTo(2);
     assertThat(bluetoothMetrics.bleScanDurationMs).isEqualTo(16 - 2);
     assertThat(bluetoothMetrics.bleOpportunisticScanCount).isEqualTo(1);
@@ -192,7 +192,7 @@ public class BluetoothMetricsCollectorTest
     ShadowSystemClock.setUptimeMillis(128);
 
     BluetoothMetrics bluetoothMetrics = new BluetoothMetrics();
-    mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics);
+    mBluetoothMetricsCollector.getSnapshot(bluetoothMetrics, null);
     assertThat(bluetoothMetrics.bleScanCount).isEqualTo(1);
     assertThat(bluetoothMetrics.bleScanDurationMs).isEqualTo(32 - 2);
     assertThat(bluetoothMetrics.bleOpportunisticScanCount).isEqualTo(0);

--- a/metrics/src/test/java/com/facebook/battery/metrics/camera/CameraMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/camera/CameraMetricsCollectorTest.java
@@ -37,10 +37,10 @@ public class CameraMetricsCollectorTest
     CameraMetricsCollector collector = new CameraMetricsCollector();
 
     collector.recordCameraOpen(testCamera);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
 
     collector.disable();
-    assertThat(collector.getSnapshot(metrics)).isFalse();
+    assertThat(collector.getSnapshot(metrics, null)).isFalse();
 
     // Sanity check no exceptions after disabling
     collector.recordPreviewStop(testCamera);
@@ -59,7 +59,7 @@ public class CameraMetricsCollectorTest
     collector.recordCameraClose(testCamera);
 
     CameraMetrics snapshot = new CameraMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
     assertThat(snapshot.cameraOpenTimeMs).isEqualTo(800);
     assertThat(snapshot.cameraPreviewTimeMs).isEqualTo(0);
   }
@@ -75,7 +75,7 @@ public class CameraMetricsCollectorTest
     collector.recordPreviewStop(testCamera);
 
     CameraMetrics snapshot = new CameraMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
     assertThat(snapshot.cameraOpenTimeMs).isEqualTo(0);
     assertThat(snapshot.cameraPreviewTimeMs).isEqualTo(300);
   }
@@ -89,7 +89,7 @@ public class CameraMetricsCollectorTest
 
     ShadowSystemClock.setUptimeMillis(1000);
     CameraMetrics snapshot = new CameraMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
     assertThat(snapshot.cameraOpenTimeMs).isEqualTo(500);
     assertThat(snapshot.cameraPreviewTimeMs).isEqualTo(0);
   }
@@ -103,7 +103,7 @@ public class CameraMetricsCollectorTest
 
     ShadowSystemClock.setUptimeMillis(1000);
     CameraMetrics snapshot = new CameraMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
     assertThat(snapshot.cameraOpenTimeMs).isEqualTo(0);
     assertThat(snapshot.cameraPreviewTimeMs).isEqualTo(300);
   }
@@ -128,7 +128,7 @@ public class CameraMetricsCollectorTest
     collector.recordCameraError(testCamera);
 
     CameraMetrics snapshot = new CameraMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
     assertThat(snapshot.cameraOpenTimeMs).isEqualTo(800);
     assertThat(snapshot.cameraPreviewTimeMs).isEqualTo(0);
   }
@@ -158,7 +158,7 @@ public class CameraMetricsCollectorTest
     collector.recordPreviewStop(testCamera);
 
     CameraMetrics snapshot = new CameraMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
     assertThat(snapshot.cameraOpenTimeMs).isEqualTo(800);
     assertThat(snapshot.cameraPreviewTimeMs).isEqualTo(300);
   }
@@ -184,7 +184,7 @@ public class CameraMetricsCollectorTest
     collector.recordCameraClose(testCamera);
 
     CameraMetrics snapshot = new CameraMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
     assertThat(snapshot.cameraOpenTimeMs).isEqualTo(0);
     assertThat(snapshot.cameraPreviewTimeMs).isEqualTo(0);
   }

--- a/metrics/src/test/java/com/facebook/battery/metrics/composite/CompositeMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/composite/CompositeMetricsCollectorTest.java
@@ -9,6 +9,8 @@ package com.facebook.battery.metrics.composite;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
+import android.content.Context;
+
 import androidx.annotation.Nullable;
 import com.facebook.battery.metrics.core.SystemMetrics;
 import com.facebook.battery.metrics.core.SystemMetricsCollector;
@@ -45,7 +47,7 @@ public class CompositeMetricsCollectorTest {
   @Test
   public void testNullSnapshot() {
     mExpectedException.expect(IllegalArgumentException.class);
-    mCollector.getSnapshot(null);
+    mCollector.getSnapshot(null, null);
   }
 
   @Test
@@ -55,7 +57,7 @@ public class CompositeMetricsCollectorTest {
     mBCollector.succeeds = true;
     mBCollector.currentValue = 120;
 
-    assertThat(mCollector.getSnapshot(mMetrics)).isTrue();
+    assertThat(mCollector.getSnapshot(mMetrics, null)).isTrue();
     assertThat(mMetrics.getMetrics().size()).isEqualTo(2);
     assertThat(mMetrics.getMetric(A.class).value).isEqualTo(100);
     assertThat(mMetrics.isValid(A.class)).isEqualTo(true);
@@ -69,7 +71,7 @@ public class CompositeMetricsCollectorTest {
     mACollector.currentValue = 100;
     mBCollector.succeeds = false;
 
-    assertThat(mCollector.getSnapshot(mMetrics)).isTrue();
+    assertThat(mCollector.getSnapshot(mMetrics, null)).isTrue();
     assertThat(mMetrics.getMetrics().size()).isEqualTo(2);
     assertThat(mMetrics.getMetric(A.class).value).isEqualTo(100);
     assertThat(mMetrics.isValid(A.class)).isEqualTo(true);
@@ -81,7 +83,7 @@ public class CompositeMetricsCollectorTest {
     mACollector.succeeds = false;
     mBCollector.succeeds = false;
 
-    assertThat(mCollector.getSnapshot(mMetrics)).isFalse();
+    assertThat(mCollector.getSnapshot(mMetrics, null)).isFalse();
     assertThat(mMetrics.getMetrics().size()).isEqualTo(2);
     assertThat(mMetrics.isValid(A.class)).isEqualTo(false);
     assertThat(mMetrics.isValid(B.class)).isEqualTo(false);
@@ -92,9 +94,9 @@ public class CompositeMetricsCollectorTest {
     mACollector.currentValue = 100;
     mACollector.succeeds = true;
     CompositeMetrics m = new CompositeMetrics().putMetric(A.class, new A());
-    mCollector.getSnapshot(m);
+    mCollector.getSnapshot(m, null);
 
-    assertThat(mCollector.getSnapshot(m)).isTrue();
+    assertThat(mCollector.getSnapshot(m, null)).isTrue();
     assertThat(m.getMetrics().size()).isEqualTo(1);
     assertThat(m.getMetric(A.class).value).isEqualTo(100);
     assertThat(m.isValid(A.class)).isEqualTo(true);
@@ -108,9 +110,9 @@ public class CompositeMetricsCollectorTest {
     mACollector.succeeds = true;
     CompositeMetrics m =
         new CompositeMetrics().putMetric(A.class, new A()).putMetric(C.class, new C());
-    mCollector.getSnapshot(m);
+    mCollector.getSnapshot(m, null);
 
-    assertThat(mCollector.getSnapshot(m)).isTrue();
+    assertThat(mCollector.getSnapshot(m, null)).isTrue();
     assertThat(m.getMetrics().size()).isEqualTo(2);
     assertThat(m.getMetric(A.class).value).isEqualTo(100);
     assertThat(m.isValid(A.class)).isEqualTo(true);
@@ -171,7 +173,7 @@ class ACollector extends SystemMetricsCollector<A> {
   boolean succeeds = true;
 
   @Override
-  public boolean getSnapshot(A snapshot) {
+  public boolean getSnapshot(A snapshot, @javax.annotation.Nullable Context context) {
     snapshot.value = currentValue;
     return succeeds;
   }
@@ -188,7 +190,7 @@ class BCollector extends SystemMetricsCollector<B> {
   boolean succeeds = true;
 
   @Override
-  public boolean getSnapshot(B snapshot) {
+  public boolean getSnapshot(B snapshot, @javax.annotation.Nullable Context context) {
     snapshot.value = currentValue;
     return succeeds;
   }

--- a/metrics/src/test/java/com/facebook/battery/metrics/core/StatefulSystemMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/core/StatefulSystemMetricsCollectorTest.java
@@ -9,9 +9,13 @@ package com.facebook.battery.metrics.core;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
+import android.content.Context;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+
+import javax.annotation.Nullable;
 
 /** Sanity check swapping in {@link StatefulSystemMetricsCollector} */
 @RunWith(RobolectricTestRunner.class)
@@ -94,7 +98,7 @@ class DummyMetricCollector extends SystemMetricsCollector<DummyMetric> {
   int currentValue;
 
   @Override
-  public boolean getSnapshot(DummyMetric snapshot) {
+  public boolean getSnapshot(DummyMetric snapshot, @Nullable Context context) {
     snapshot.value = currentValue;
     return true;
   }

--- a/metrics/src/test/java/com/facebook/battery/metrics/core/SystemMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/core/SystemMetricsCollectorTest.java
@@ -20,7 +20,7 @@ public abstract class SystemMetricsCollectorTest<
   public void testNullSnapshot() throws Exception {
     mExpectedException.expect(IllegalArgumentException.class);
     T instance = getClazz().newInstance();
-    instance.getSnapshot(null);
+    instance.getSnapshot(null, null);
   }
 
   protected abstract Class<T> getClazz();

--- a/metrics/src/test/java/com/facebook/battery/metrics/cpu/CpuFrequencyMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/cpu/CpuFrequencyMetricsCollectorTest.java
@@ -48,7 +48,7 @@ public class CpuFrequencyMetricsCollectorTest
             });
 
     CpuFrequencyMetrics metrics = collector.createMetrics();
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
 
     assertThat(metrics.timeInStateS.length).isEqualTo(4);
     assertThat(metrics.timeInStateS[0].size()).isEqualTo(2);
@@ -76,7 +76,7 @@ public class CpuFrequencyMetricsCollectorTest
             });
 
     CpuFrequencyMetrics metrics = collector.createMetrics();
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
 
     assertThat(metrics.timeInStateS.length).isEqualTo(4);
     assertThat(metrics.timeInStateS[0].size()).isEqualTo(1);
@@ -97,7 +97,7 @@ public class CpuFrequencyMetricsCollectorTest
             });
 
     CpuFrequencyMetrics metrics = collector.createMetrics();
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
 
     assertThat(metrics.timeInStateS.length).isEqualTo(4);
     assertThat(metrics.timeInStateS[0].size()).isEqualTo(0);
@@ -110,7 +110,7 @@ public class CpuFrequencyMetricsCollectorTest
             new String[] {"everything", "is", "horribly", "broken"});
 
     CpuFrequencyMetrics metrics = collector.createMetrics();
-    assertThat(collector.getSnapshot(metrics)).isFalse();
+    assertThat(collector.getSnapshot(metrics, null)).isFalse();
   }
 
   private String createFile(String contents) throws IOException {

--- a/metrics/src/test/java/com/facebook/battery/metrics/cpu/CpuMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/cpu/CpuMetricsCollectorTest.java
@@ -43,7 +43,7 @@ public class CpuMetricsCollectorTest
         new TestableCpuMetricsCollector().setPath(createFile("I am a weird android manufacturer"));
 
     CpuMetrics snapshot = new CpuMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isFalse();
+    assertThat(collector.getSnapshot(snapshot, null)).isFalse();
   }
 
   @Test
@@ -56,7 +56,7 @@ public class CpuMetricsCollectorTest
         new TestableCpuMetricsCollector().setPath(createFile(testStringBuilder.toString()));
 
     CpuMetrics snapshot = new CpuMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isFalse();
+    assertThat(collector.getSnapshot(snapshot, null)).isFalse();
   }
 
   @Test
@@ -71,7 +71,7 @@ public class CpuMetricsCollectorTest
     String path = createFile(initialEntry.toString());
     TestableCpuMetricsCollector collector = new TestableCpuMetricsCollector().setPath(path);
     CpuMetrics snapshot = new CpuMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
     verify(logger, never()).wtf(anyString(), anyString(), (Throwable) any());
 
     StringBuilder secondEntry = new StringBuilder();
@@ -79,7 +79,7 @@ public class CpuMetricsCollectorTest
       secondEntry.append(i * 1000).append(' ');
     }
     overwriteFile(new File(path), secondEntry.toString());
-    assertThat(collector.getSnapshot(snapshot)).isFalse();
+    assertThat(collector.getSnapshot(snapshot, null)).isFalse();
     verify(logger, times(1)).wtf(anyString(), anyString(), (Throwable) any());
   }
 
@@ -91,7 +91,7 @@ public class CpuMetricsCollectorTest
         new TestableCpuMetricsCollector().setPath(createFile(stat));
 
     CpuMetrics snapshot = new CpuMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
 
     assertThat(snapshot.userTimeS).isEqualTo(9852.0 / 100);
     assertThat(snapshot.systemTimeS).isEqualTo(889.0 / 100);
@@ -109,7 +109,7 @@ public class CpuMetricsCollectorTest
         new TestableCpuMetricsCollector().setPath(createFile(testStringBuilder.toString()));
 
     CpuMetrics snapshot = new CpuMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
 
     assertThat(snapshot.userTimeS).isEqualTo(13);
     assertThat(snapshot.systemTimeS).isEqualTo(14);
@@ -122,7 +122,7 @@ public class CpuMetricsCollectorTest
     TestableCpuMetricsCollector collector = new TestableCpuMetricsCollector().setPath("");
 
     CpuMetrics snapshot = new CpuMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isFalse();
+    assertThat(collector.getSnapshot(snapshot, null)).isFalse();
   }
 
   private String createFile(String contents) throws IOException {

--- a/metrics/src/test/java/com/facebook/battery/metrics/devicebattery/DeviceBatteryMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/devicebattery/DeviceBatteryMetricsCollectorTest.java
@@ -9,7 +9,6 @@ package com.facebook.battery.metrics.devicebattery;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,13 +18,12 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.BatteryManager;
 import com.facebook.battery.metrics.core.ShadowSystemClock;
-import java.util.List;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.robolectric.RobolectricTestRunner;
 
@@ -51,7 +49,7 @@ public class DeviceBatteryMetricsCollectorTest {
     DeviceBatteryMetrics metrics = new DeviceBatteryMetrics();
     DeviceBatteryMetricsCollector collector = new DeviceBatteryMetricsCollector(mContext);
     ShadowSystemClock.setElapsedRealtime(10000);
-    collector.getSnapshot(metrics);
+    collector.getSnapshot(metrics, null);
     verifySnapshot(metrics, 20, 0, 5000);
   }
 
@@ -60,7 +58,7 @@ public class DeviceBatteryMetricsCollectorTest {
   public void testEmptyBatteryIntent() {
     DeviceBatteryMetrics metrics = new DeviceBatteryMetrics();
     DeviceBatteryMetricsCollector collector = new DeviceBatteryMetricsCollector(mContext);
-    collector.getSnapshot(metrics);
+    collector.getSnapshot(metrics, null);
   }
 
   @Test
@@ -70,7 +68,7 @@ public class DeviceBatteryMetricsCollectorTest {
         .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 20, 100));
     DeviceBatteryMetricsCollector collector = new DeviceBatteryMetricsCollector(mContext);
     mExpectedException.expect(IllegalArgumentException.class);
-    collector.getSnapshot(null);
+    collector.getSnapshot(null, null);
   }
 
   @Test
@@ -80,78 +78,78 @@ public class DeviceBatteryMetricsCollectorTest {
         .thenThrow(new SecurityException("Testing exception"));
     DeviceBatteryMetrics metrics = new DeviceBatteryMetrics();
     DeviceBatteryMetricsCollector collector = new DeviceBatteryMetricsCollector(mContext);
-    collector.getSnapshot(metrics);
+    collector.getSnapshot(metrics, null);
     assertThat(metrics.batteryLevelPct).isEqualTo(DeviceBatteryMetricsCollector.UNKNOWN_LEVEL);
   }
 
   @Test
   public void testSnapshotAfterValidBroadcasts() {
     // Set up the collector
-    ShadowSystemClock.setElapsedRealtime(5000);
-    when(mContext.registerReceiver(
-            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 50, 100));
-    when(mContext.registerReceiver(
-            Matchers.isNotNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-        .thenReturn(null);
-    DeviceBatteryMetrics metrics = new DeviceBatteryMetrics();
-    DeviceBatteryMetricsCollector collector = new DeviceBatteryMetricsCollector(mContext);
-
-    // Get a handle of the receiver
-    ArgumentCaptor<BroadcastReceiver> captor = ArgumentCaptor.forClass(BroadcastReceiver.class);
-    verify(mContext, times(2)).registerReceiver(captor.capture(), Matchers.any(IntentFilter.class));
-    final List<BroadcastReceiver> receivers = captor.getAllValues();
-    assertThat(receivers.size()).isEqualTo(2);
-    BroadcastReceiver receiver = receivers.get(1);
-    assertThat(receiver).isNotNull();
-
-    // Simulate connecting and disconnecting power
-    ShadowSystemClock.setElapsedRealtime(9000);
-    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
-    ShadowSystemClock.setElapsedRealtime(15000);
-    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
-    ShadowSystemClock.setElapsedRealtime(22000);
-    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
-
-    // Get snapshot
-    ShadowSystemClock.setElapsedRealtime(28000);
-    when(mContext.registerReceiver(
-            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 20, 100));
-    collector.getSnapshot(metrics);
-    verifySnapshot(metrics, 20, 12000, 11000);
-
-    // Power Connected and test getSnapshot
-    ShadowSystemClock.setElapsedRealtime(30000);
-    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
-    ShadowSystemClock.setElapsedRealtime(42000);
-    when(mContext.registerReceiver(
-            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 30, 100));
-    collector.getSnapshot(metrics);
-    verifySnapshot(metrics, 30, 14000, 23000);
-
-    // PowerConnected and testGetSnapshot (Check for two consecutive CONNECTED intents)
-    ShadowSystemClock.setElapsedRealtime(50000);
-    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
-    ShadowSystemClock.setElapsedRealtime(51000);
-    when(mContext.registerReceiver(
-            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 40, 100));
-    collector.getSnapshot(metrics);
-    verifySnapshot(metrics, 40, 14000, 32000);
-
-    // Test for 2 consecutive powerdisconnected intents
-    ShadowSystemClock.setElapsedRealtime(55000);
-    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
-    ShadowSystemClock.setElapsedRealtime(59000);
-    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
-    ShadowSystemClock.setElapsedRealtime(65000);
-    when(mContext.registerReceiver(
-            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 60, 100));
-    collector.getSnapshot(metrics);
-    verifySnapshot(metrics, 60, 24000, 36000);
+//    ShadowSystemClock.setElapsedRealtime(5000);
+//    when(mContext.registerReceiver(
+//            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+//        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 50, 100));
+//    when(mContext.registerReceiver(
+//            Matchers.isNotNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+//        .thenReturn(null);
+//    DeviceBatteryMetrics metrics = new DeviceBatteryMetrics();
+//    DeviceBatteryMetricsCollector collector = new DeviceBatteryMetricsCollector(mContext);
+//
+//    // Get a handle of the receiver
+//    ArgumentCaptor<BroadcastReceiver> captor = ArgumentCaptor.forClass(BroadcastReceiver.class);
+//    verify(mContext, times(2)).registerReceiver(captor.capture(), Matchers.any(IntentFilter.class));
+//    final List<BroadcastReceiver> receivers = captor.getAllValues();
+//    assertThat(receivers.size()).isEqualTo(2);
+//    BroadcastReceiver receiver = receivers.get(1);
+//    assertThat(receiver).isNotNull();
+//
+//    // Simulate connecting and disconnecting power
+//    ShadowSystemClock.setElapsedRealtime(9000);
+//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
+//    ShadowSystemClock.setElapsedRealtime(15000);
+//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
+//    ShadowSystemClock.setElapsedRealtime(22000);
+//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
+//
+//    // Get snapshot
+//    ShadowSystemClock.setElapsedRealtime(28000);
+//    when(mContext.registerReceiver(
+//            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+//        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 20, 100));
+//    collector.getSnapshot(metrics);
+//    verifySnapshot(metrics, 20, 12000, 11000);
+//
+//    // Power Connected and test getSnapshot
+//    ShadowSystemClock.setElapsedRealtime(30000);
+//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
+//    ShadowSystemClock.setElapsedRealtime(42000);
+//    when(mContext.registerReceiver(
+//            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+//        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 30, 100));
+//    collector.getSnapshot(metrics);
+//    verifySnapshot(metrics, 30, 14000, 23000);
+//
+//    // PowerConnected and testGetSnapshot (Check for two consecutive CONNECTED intents)
+//    ShadowSystemClock.setElapsedRealtime(50000);
+//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
+//    ShadowSystemClock.setElapsedRealtime(51000);
+//    when(mContext.registerReceiver(
+//            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+//        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 40, 100));
+//    collector.getSnapshot(metrics);
+//    verifySnapshot(metrics, 40, 14000, 32000);
+//
+//    // Test for 2 consecutive powerdisconnected intents
+//    ShadowSystemClock.setElapsedRealtime(55000);
+//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
+//    ShadowSystemClock.setElapsedRealtime(59000);
+//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
+//    ShadowSystemClock.setElapsedRealtime(65000);
+//    when(mContext.registerReceiver(
+//            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+//        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 60, 100));
+//    collector.getSnapshot(metrics);
+//    verifySnapshot(metrics, 60, 24000, 36000);
   }
 
   private static Intent createBatteryIntent(int status, int level, int scale) {

--- a/metrics/src/test/java/com/facebook/battery/metrics/devicebattery/DeviceBatteryMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/devicebattery/DeviceBatteryMetricsCollectorTest.java
@@ -9,6 +9,7 @@ package com.facebook.battery.metrics.devicebattery;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,8 +25,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.robolectric.RobolectricTestRunner;
+
+import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
 @org.robolectric.annotation.Config(shadows = {ShadowSystemClock.class})
@@ -84,72 +88,72 @@ public class DeviceBatteryMetricsCollectorTest {
 
   @Test
   public void testSnapshotAfterValidBroadcasts() {
-    // Set up the collector
-//    ShadowSystemClock.setElapsedRealtime(5000);
-//    when(mContext.registerReceiver(
-//            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-//        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 50, 100));
-//    when(mContext.registerReceiver(
-//            Matchers.isNotNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-//        .thenReturn(null);
-//    DeviceBatteryMetrics metrics = new DeviceBatteryMetrics();
-//    DeviceBatteryMetricsCollector collector = new DeviceBatteryMetricsCollector(mContext);
-//
-//    // Get a handle of the receiver
-//    ArgumentCaptor<BroadcastReceiver> captor = ArgumentCaptor.forClass(BroadcastReceiver.class);
-//    verify(mContext, times(2)).registerReceiver(captor.capture(), Matchers.any(IntentFilter.class));
-//    final List<BroadcastReceiver> receivers = captor.getAllValues();
-//    assertThat(receivers.size()).isEqualTo(2);
-//    BroadcastReceiver receiver = receivers.get(1);
-//    assertThat(receiver).isNotNull();
-//
-//    // Simulate connecting and disconnecting power
-//    ShadowSystemClock.setElapsedRealtime(9000);
-//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
-//    ShadowSystemClock.setElapsedRealtime(15000);
-//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
-//    ShadowSystemClock.setElapsedRealtime(22000);
-//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
-//
-//    // Get snapshot
-//    ShadowSystemClock.setElapsedRealtime(28000);
-//    when(mContext.registerReceiver(
-//            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-//        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 20, 100));
-//    collector.getSnapshot(metrics);
-//    verifySnapshot(metrics, 20, 12000, 11000);
-//
-//    // Power Connected and test getSnapshot
-//    ShadowSystemClock.setElapsedRealtime(30000);
-//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
-//    ShadowSystemClock.setElapsedRealtime(42000);
-//    when(mContext.registerReceiver(
-//            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-//        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 30, 100));
-//    collector.getSnapshot(metrics);
-//    verifySnapshot(metrics, 30, 14000, 23000);
-//
-//    // PowerConnected and testGetSnapshot (Check for two consecutive CONNECTED intents)
-//    ShadowSystemClock.setElapsedRealtime(50000);
-//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
-//    ShadowSystemClock.setElapsedRealtime(51000);
-//    when(mContext.registerReceiver(
-//            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-//        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 40, 100));
-//    collector.getSnapshot(metrics);
-//    verifySnapshot(metrics, 40, 14000, 32000);
-//
-//    // Test for 2 consecutive powerdisconnected intents
-//    ShadowSystemClock.setElapsedRealtime(55000);
-//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
-//    ShadowSystemClock.setElapsedRealtime(59000);
-//    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
-//    ShadowSystemClock.setElapsedRealtime(65000);
-//    when(mContext.registerReceiver(
-//            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
-//        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 60, 100));
-//    collector.getSnapshot(metrics);
-//    verifySnapshot(metrics, 60, 24000, 36000);
+     //Set up the collector
+    ShadowSystemClock.setElapsedRealtime(5000);
+    when(mContext.registerReceiver(
+            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 50, 100));
+    when(mContext.registerReceiver(
+            Matchers.isNotNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+        .thenReturn(null);
+    DeviceBatteryMetrics metrics = new DeviceBatteryMetrics();
+    DeviceBatteryMetricsCollector collector = new DeviceBatteryMetricsCollector(mContext);
+
+    // Get a handle of the receiver
+    ArgumentCaptor<BroadcastReceiver> captor = ArgumentCaptor.forClass(BroadcastReceiver.class);
+    verify(mContext, times(2)).registerReceiver(captor.capture(), Matchers.any(IntentFilter.class));
+    final List<BroadcastReceiver> receivers = captor.getAllValues();
+    assertThat(receivers.size()).isEqualTo(2);
+    BroadcastReceiver receiver = receivers.get(1);
+    assertThat(receiver).isNotNull();
+
+    // Simulate connecting and disconnecting power
+    ShadowSystemClock.setElapsedRealtime(9000);
+    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
+    ShadowSystemClock.setElapsedRealtime(15000);
+    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
+    ShadowSystemClock.setElapsedRealtime(22000);
+    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
+
+    // Get snapshot
+    ShadowSystemClock.setElapsedRealtime(28000);
+    when(mContext.registerReceiver(
+            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 20, 100));
+    collector.getSnapshot(metrics, null);
+    verifySnapshot(metrics, 20, 12000, 11000);
+
+    // Power Connected and test getSnapshot
+    ShadowSystemClock.setElapsedRealtime(30000);
+    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
+    ShadowSystemClock.setElapsedRealtime(42000);
+    when(mContext.registerReceiver(
+            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 30, 100));
+    collector.getSnapshot(metrics, null);
+    verifySnapshot(metrics, 30, 14000, 23000);
+
+    // PowerConnected and testGetSnapshot (Check for two consecutive CONNECTED intents)
+    ShadowSystemClock.setElapsedRealtime(50000);
+    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_CONNECTED));
+    ShadowSystemClock.setElapsedRealtime(51000);
+    when(mContext.registerReceiver(
+            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 40, 100));
+    collector.getSnapshot(metrics, null);
+    verifySnapshot(metrics, 40, 14000, 32000);
+
+    // Test for 2 consecutive powerdisconnected intents
+    ShadowSystemClock.setElapsedRealtime(55000);
+    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
+    ShadowSystemClock.setElapsedRealtime(59000);
+    receiver.onReceive(mContext, new Intent(Intent.ACTION_POWER_DISCONNECTED));
+    ShadowSystemClock.setElapsedRealtime(65000);
+    when(mContext.registerReceiver(
+            Matchers.isNull(BroadcastReceiver.class), Matchers.any(IntentFilter.class)))
+        .thenReturn(createBatteryIntent(BatteryManager.BATTERY_STATUS_CHARGING, 60, 100));
+    collector.getSnapshot(metrics, null);
+    verifySnapshot(metrics, 60, 24000, 36000);
   }
 
   private static Intent createBatteryIntent(int status, int level, int scale) {

--- a/metrics/src/test/java/com/facebook/battery/metrics/disk/DiskMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/disk/DiskMetricsCollectorTest.java
@@ -37,14 +37,14 @@ public class DiskMetricsCollectorTest
             .setPath(createFile("I am a weird android"), createFile("manufacturer"));
 
     DiskMetrics snapshot = new DiskMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isFalse();
+    assertThat(collector.getSnapshot(snapshot, null)).isFalse();
   }
 
   @Test
   public void testDefaultDisabled() throws Exception {
     DiskMetricsCollector collector = new DiskMetricsCollector();
     DiskMetrics snapshot = new DiskMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isFalse();
+    assertThat(collector.getSnapshot(snapshot, null)).isFalse();
     assertThat(snapshot.rcharBytes).isEqualTo(0);
     assertThat(snapshot.wcharBytes).isEqualTo(0);
   }
@@ -67,7 +67,7 @@ public class DiskMetricsCollectorTest
         new DiskMetricsCollectorWithProcFile().setPath(createFile(io), createFile(stat));
 
     DiskMetrics snapshot = new DiskMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
 
     assertThat(snapshot.rcharBytes).isEqualTo(100);
     assertThat(snapshot.wcharBytes).isEqualTo(101);
@@ -98,9 +98,9 @@ public class DiskMetricsCollectorTest
         new DiskMetricsCollectorWithProcFile().setPath(createFile(io), createFile(stat));
 
     DiskMetrics snapshot = new DiskMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
 
     assertThat(snapshot.rcharBytes).isEqualTo(100);
     assertThat(snapshot.wcharBytes).isEqualTo(101);
@@ -131,7 +131,7 @@ public class DiskMetricsCollectorTest
         new DiskMetricsCollectorWithProcFile().setPath(createFile(io), createFile(stat));
 
     DiskMetrics snapshot = new DiskMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
 
     assertThat(snapshot.rcharBytes).isEqualTo(100);
     assertThat(snapshot.wcharBytes).isEqualTo(101);

--- a/metrics/src/test/java/com/facebook/battery/metrics/memory/MemoryMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/memory/MemoryMetricsCollectorTest.java
@@ -39,8 +39,8 @@ public class MemoryMetricsCollectorTest
             .setPath(createFile("I am a weird android manufacturer"));
 
     MemoryMetrics snapshot = new MemoryMetrics();
-    collector.getSnapshot(snapshot);
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    collector.getSnapshot(snapshot, null);
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
 
     assertThat(snapshot.vmSizeKb).isEqualTo(-1);
     assertThat(snapshot.vmRssKb).isEqualTo(-1);
@@ -53,7 +53,7 @@ public class MemoryMetricsCollectorTest
         new MemoryMetricsCollectorWithProcFile().setPath(createFile(statm));
 
     MemoryMetrics snapshot = new MemoryMetrics();
-    assertThat(collector.getSnapshot(snapshot)).isTrue();
+    assertThat(collector.getSnapshot(snapshot, null)).isTrue();
 
     assertThat(snapshot.vmSizeKb).isEqualTo(16);
     assertThat(snapshot.vmRssKb).isEqualTo(8);
@@ -66,9 +66,9 @@ public class MemoryMetricsCollectorTest
 
     MemoryMetrics snapshot = new MemoryMetrics();
     MemoryMetricsCollector collector = new MemoryMetricsCollector();
-    collector.getSnapshot(snapshot);
+    collector.getSnapshot(snapshot, null);
 
-    assertThat(collector.getSnapshot(snapshot)).isFalse();
+    assertThat(collector.getSnapshot(snapshot, null)).isFalse();
     assertThat(snapshot.nativeHeapSizeKb).isEqualTo(0);
     assertThat(snapshot.nativeHeapAllocatedKb).isEqualTo(0);
   }
@@ -81,7 +81,7 @@ public class MemoryMetricsCollectorTest
     MemoryMetrics snapshot = new MemoryMetrics();
     MemoryMetricsCollector collector = new MemoryMetricsCollector();
     collector.enable();
-    collector.getSnapshot(snapshot);
+    collector.getSnapshot(snapshot, null);
 
     assertThat(snapshot.nativeHeapSizeKb).isEqualTo(4);
     assertThat(snapshot.nativeHeapAllocatedKb).isEqualTo(3);
@@ -95,8 +95,8 @@ public class MemoryMetricsCollectorTest
     MemoryMetrics first = new MemoryMetrics();
     MemoryMetrics second = new MemoryMetrics();
 
-    collector.getSnapshot(first);
-    collector.getSnapshot(second);
+    collector.getSnapshot(first, null);
+    collector.getSnapshot(second, null);
 
     assertThat(first.sequenceNumber).isEqualTo(1);
     assertThat(second.sequenceNumber).isEqualTo(2);
@@ -113,11 +113,11 @@ public class MemoryMetricsCollectorTest
 
     ShadowDebug.setNativeHeapSize(4 * 1024);
     ShadowDebug.setNativeHeapAllocatedSize(3 * 1024);
-    collector.getSnapshot(first);
+    collector.getSnapshot(first, null);
 
     ShadowDebug.setNativeHeapSize(8 * 1024);
     ShadowDebug.setNativeHeapAllocatedSize(6 * 1024);
-    collector.getSnapshot(second);
+    collector.getSnapshot(second, null);
 
     first.sum(second, output);
     assertThat(output.nativeHeapSizeKb).isEqualTo(8);
@@ -135,11 +135,11 @@ public class MemoryMetricsCollectorTest
 
     ShadowDebug.setNativeHeapSize(4 * 1024);
     ShadowDebug.setNativeHeapAllocatedSize(3 * 1024);
-    collector.getSnapshot(first);
+    collector.getSnapshot(first, null);
 
     ShadowDebug.setNativeHeapSize(8 * 1024);
     ShadowDebug.setNativeHeapAllocatedSize(6 * 1024);
-    collector.getSnapshot(second);
+    collector.getSnapshot(second, null);
 
     second.sum(first, output);
     assertThat(output.nativeHeapSizeKb).isEqualTo(8);
@@ -155,7 +155,7 @@ public class MemoryMetricsCollectorTest
     collector.enable();
     MemoryMetrics snapshot = new MemoryMetrics();
 
-    collector.getSnapshot(snapshot);
+    collector.getSnapshot(snapshot, null);
     assertThat(snapshot.javaHeapMaxSizeKb).isEqualTo(8);
     assertThat(snapshot.nativeHeapAllocatedKb).isEqualTo(6);
   }

--- a/metrics/src/test/java/com/facebook/battery/metrics/memory/MemoryMetricsTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/memory/MemoryMetricsTest.java
@@ -39,8 +39,8 @@ public class MemoryMetricsTest extends SystemMetricsTest<MemoryMetrics> {
     MemoryMetricsCollector collector = new MemoryMetricsCollector();
     collector.enable();
 
-    collector.getSnapshot(a);
-    collector.getSnapshot(b);
+    collector.getSnapshot(a, null);
+    collector.getSnapshot(b, null);
 
     sum = b.sum(a, sum);
     assertThat(sum.sequenceNumber).isEqualTo(b.sequenceNumber);
@@ -71,8 +71,8 @@ public class MemoryMetricsTest extends SystemMetricsTest<MemoryMetrics> {
     MemoryMetricsCollector collector = new MemoryMetricsCollector();
     collector.enable();
 
-    collector.getSnapshot(a);
-    collector.getSnapshot(b);
+    collector.getSnapshot(a, null);
+    collector.getSnapshot(b, null);
 
     sum = b.diff(a, sum);
     assertThat(sum.sequenceNumber).isEqualTo(b.sequenceNumber);

--- a/metrics/src/test/java/com/facebook/battery/metrics/network/NetworkMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/network/NetworkMetricsCollectorTest.java
@@ -53,7 +53,7 @@ public class NetworkMetricsCollectorTest {
     mBytesCollector.yieldTotalBytes(bytes);
 
     NetworkMetrics metrics = mMetricsCollector.createMetrics();
-    boolean hasMetrics = mMetricsCollector.getSnapshot(metrics);
+    boolean hasMetrics = mMetricsCollector.getSnapshot(metrics, null);
     assertThat(hasMetrics).isTrue();
 
     NetworkMetrics expected = new NetworkMetrics();
@@ -72,7 +72,7 @@ public class NetworkMetricsCollectorTest {
     mBytesCollector.yieldTotalBytes(bytes);
 
     NetworkMetrics metrics = mMetricsCollector.createMetrics();
-    boolean hasMetrics = mMetricsCollector.getSnapshot(metrics);
+    boolean hasMetrics = mMetricsCollector.getSnapshot(metrics, null);
     assertThat(hasMetrics).isTrue();
 
     NetworkMetrics expected = new NetworkMetrics();
@@ -91,19 +91,19 @@ public class NetworkMetricsCollectorTest {
     mBytesCollector.yieldTotalBytes(bytes);
 
     NetworkMetrics metrics = mMetricsCollector.createMetrics();
-    assertThat(mMetricsCollector.getSnapshot(metrics)).isTrue();
+    assertThat(mMetricsCollector.getSnapshot(metrics, null)).isTrue();
 
     bytes[MOBILE | TX | FG] = 90;
     mBytesCollector.yieldTotalBytes(bytes);
 
-    assertThat(mMetricsCollector.getSnapshot(metrics)).isFalse();
+    assertThat(mMetricsCollector.getSnapshot(metrics, null)).isFalse();
     verify(logger, times(1)).wtf(anyString(), anyString(), (Throwable) any());
-    assertThat(mMetricsCollector.getSnapshot(metrics)).isFalse();
+    assertThat(mMetricsCollector.getSnapshot(metrics, null)).isFalse();
 
     // Validate that any further snapshots, even if increasing, are disabled
     bytes[MOBILE | TX | FG] = 1000;
     mBytesCollector.yieldTotalBytes(bytes);
-    assertThat(mMetricsCollector.getSnapshot(metrics)).isFalse();
+    assertThat(mMetricsCollector.getSnapshot(metrics, null)).isFalse();
 
     // No new error logged because we've given up on this user session
     verify(logger, times(1)).wtf(anyString(), anyString(), (Throwable) any());

--- a/metrics/src/test/java/com/facebook/battery/metrics/sensor/SensorMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/sensor/SensorMetricsCollectorTest.java
@@ -42,7 +42,7 @@ public class SensorMetricsCollectorTest
 
   @Test
   public void test_blank() {
-    collector.getSnapshot(metrics);
+    collector.getSnapshot(metrics, null);
     assertThat(metrics.total.activeTimeMs).isEqualTo(0);
     assertThat(metrics.total.powerMah).isEqualTo(0);
     assertThat(metrics.total.wakeUpTimeMs).isEqualTo(0);
@@ -52,7 +52,7 @@ public class SensorMetricsCollectorTest
   public void test_disabled() {
     collector.disable();
 
-    assertThat(collector.getSnapshot(metrics)).isFalse();
+    assertThat(collector.getSnapshot(metrics, null)).isFalse();
   }
 
   /**
@@ -69,14 +69,14 @@ public class SensorMetricsCollectorTest
     collector.register(listener, sensor);
 
     ShadowSystemClock.setElapsedRealtime(10);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
 
     assertThat(metrics.total.powerMah).isEqualTo((((double) sensor.getPower()) * 9) / 3600 / 1000);
     assertThat(metrics.total.wakeUpTimeMs).isEqualTo(0);
     assertThat(metrics.total.activeTimeMs).isEqualTo(9);
 
     ShadowSystemClock.setElapsedRealtime(20);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
 
     assertThat(metrics.total.powerMah).isEqualTo((((double) sensor.getPower()) * 19) / 3600 / 1000);
     assertThat(metrics.total.wakeUpTimeMs).isEqualTo(0);
@@ -85,7 +85,7 @@ public class SensorMetricsCollectorTest
     collector.unregister(listener, null);
 
     ShadowSystemClock.setElapsedRealtime(50);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
     assertThat(metrics.total.activeTimeMs).isEqualTo(19);
   }
 
@@ -106,27 +106,27 @@ public class SensorMetricsCollectorTest
     collector.register(listener, sensor);
 
     ShadowSystemClock.setElapsedRealtime(5);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
     assertThat(metrics.total.activeTimeMs).isEqualTo(4);
 
     ShadowSystemClock.setElapsedRealtime(10);
     collector.register(listenerB, sensor);
 
     ShadowSystemClock.setElapsedRealtime(11);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
     assertThat(metrics.total.activeTimeMs).isEqualTo(10);
 
     ShadowSystemClock.setElapsedRealtime(15);
     collector.unregister(listenerB, null);
 
     ShadowSystemClock.setElapsedRealtime(20);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
     assertThat(metrics.total.activeTimeMs).isEqualTo(19);
 
     collector.unregister(listener, null);
 
     ShadowSystemClock.setElapsedRealtime(25);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
     assertThat(metrics.total.activeTimeMs).isEqualTo(19);
   }
 
@@ -153,7 +153,7 @@ public class SensorMetricsCollectorTest
 
     ShadowSystemClock.setElapsedRealtime(15);
     collector.unregister(listener, null);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
     assertThat(metrics.total.activeTimeMs).isEqualTo(5 + 14);
     assertThat(metrics.total.powerMah)
         .isEqualTo((5 * 20.0) / 3600 / 1000 + (14 * 10.0) / 3600 / 1000);
@@ -177,28 +177,28 @@ public class SensorMetricsCollectorTest
     collector.register(listener, sensor);
 
     ShadowSystemClock.setElapsedRealtime(5);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
     assertThat(metrics.total.activeTimeMs).isEqualTo(4);
 
     ShadowSystemClock.setElapsedRealtime(10);
     collector.register(listenerB, sensorB);
 
     ShadowSystemClock.setElapsedRealtime(13);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
     assertThat(metrics.total.activeTimeMs).isEqualTo(12 + 3);
 
     ShadowSystemClock.setElapsedRealtime(15);
     collector.unregister(listener, null);
 
     ShadowSystemClock.setElapsedRealtime(18);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
     assertThat(metrics.total.activeTimeMs).isEqualTo(14 + 8);
 
     ShadowSystemClock.setElapsedRealtime(20);
     collector.unregister(listenerB, null);
 
     ShadowSystemClock.setElapsedRealtime(50);
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
     assertThat(metrics.total.activeTimeMs).isEqualTo(14 + 10);
   }
 
@@ -234,7 +234,7 @@ public class SensorMetricsCollectorTest
     ShadowSystemClock.setElapsedRealtime(50);
 
     metrics.isAttributionEnabled = true;
-    assertThat(collector.getSnapshot(metrics)).isTrue();
+    assertThat(collector.getSnapshot(metrics, null)).isTrue();
     assertThat(metrics.total.activeTimeMs).isEqualTo(14 + 10);
     assertThat(metrics.sensorConsumption.size()).isEqualTo(2);
     assertThat(metrics.sensorConsumption.get(1337).activeTimeMs).isEqualTo(14);

--- a/metrics/src/test/java/com/facebook/battery/metrics/time/TimeMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/time/TimeMetricsCollectorTest.java
@@ -26,7 +26,7 @@ public class TimeMetricsCollectorTest
     ShadowSystemClock.setElapsedRealtime(9876);
     TimeMetrics snapshot = new TimeMetrics();
     TimeMetricsCollector collector = new TimeMetricsCollector();
-    collector.getSnapshot(snapshot);
+    collector.getSnapshot(snapshot, null);
 
     assertThat(snapshot.uptimeMs).isEqualTo(1234);
     assertThat(snapshot.realtimeMs).isEqualTo(9876);

--- a/metrics/src/test/java/com/facebook/battery/metrics/wakelock/WakeLockMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/wakelock/WakeLockMetricsCollectorTest.java
@@ -58,24 +58,24 @@ public class WakeLockMetricsCollectorTest
     PowerManager.WakeLock wakelockA = mPowerManager.newWakeLock(0, "testA");
     mCollector.newWakeLock(wakelockA, 0, "testA");
 
-    mCollector.getSnapshot(metrics);
+    mCollector.getSnapshot(metrics, null);
     assertThat(metrics.heldTimeMs).as("Held time at beginning").isEqualTo(0);
 
     ShadowSystemClock.setUptimeMillis(1);
     mCollector.acquire(wakelockA, -1);
 
     ShadowSystemClock.setUptimeMillis(61);
-    mCollector.getSnapshot(metrics);
+    mCollector.getSnapshot(metrics, null);
     assertThat(metrics.heldTimeMs).as("Intermediate held time").isEqualTo(60);
 
     ShadowSystemClock.setUptimeMillis(91);
     mCollector.release(wakelockA, 0);
 
-    mCollector.getSnapshot(metrics);
+    mCollector.getSnapshot(metrics, null);
     assertThat(metrics.heldTimeMs).as("Held time at release").isEqualTo(90);
 
     ShadowSystemClock.setUptimeMillis(121);
-    mCollector.getSnapshot(metrics);
+    mCollector.getSnapshot(metrics, null);
     assertThat(metrics.heldTimeMs).as("Final held time").isEqualTo(90);
   }
 
@@ -98,7 +98,7 @@ public class WakeLockMetricsCollectorTest
     mCollector.newWakeLock(wakeLockB, 0, "testB");
 
     ShadowSystemClock.setUptimeMillis(1);
-    mCollector.getSnapshot(metrics);
+    mCollector.getSnapshot(metrics, null);
     assertThat(metrics.heldTimeMs).as("Initialization").isEqualTo(0);
     assertThat(metrics.tagTimeMs.isEmpty()).isFalse();
     assertThat(metrics.tagTimeMs.get("testA")).isEqualTo(0);
@@ -106,32 +106,32 @@ public class WakeLockMetricsCollectorTest
 
     ShadowSystemClock.setUptimeMillis(1);
     mCollector.acquire(wakeLockA, -1);
-    mCollector.getSnapshot(metrics);
+    mCollector.getSnapshot(metrics, null);
     assertThat(metrics.heldTimeMs).as("Acquired A").isEqualTo(0);
 
     ShadowSystemClock.setUptimeMillis(31);
     mCollector.acquire(wakeLockB, -1);
-    mCollector.getSnapshot(metrics);
+    mCollector.getSnapshot(metrics, null);
     assertThat(metrics.heldTimeMs).as("Acquired B").isEqualTo(30);
     assertThat(metrics.tagTimeMs.get("testA")).isEqualTo(30);
     assertThat(metrics.tagTimeMs.get("testB")).isEqualTo(0);
 
     ShadowSystemClock.setUptimeMillis(61);
     mCollector.release(wakeLockB, 0);
-    mCollector.getSnapshot(metrics);
+    mCollector.getSnapshot(metrics, null);
     assertThat(metrics.heldTimeMs).as("Released B").isEqualTo(60);
     assertThat(metrics.tagTimeMs.get("testA")).isEqualTo(60);
     assertThat(metrics.tagTimeMs.get("testB")).isEqualTo(30);
 
     ShadowSystemClock.setUptimeMillis(91);
     mCollector.release(wakeLockA, 0);
-    mCollector.getSnapshot(metrics);
+    mCollector.getSnapshot(metrics, null);
     assertThat(metrics.heldTimeMs).as("Released A").isEqualTo(90);
     assertThat(metrics.tagTimeMs.get("testA")).isEqualTo(90);
     assertThat(metrics.tagTimeMs.get("testB")).isEqualTo(30);
 
     ShadowSystemClock.setUptimeMillis(121);
-    mCollector.getSnapshot(metrics);
+    mCollector.getSnapshot(metrics, null);
     assertThat(metrics.heldTimeMs).as("Final").isEqualTo(90);
     assertThat(metrics.tagTimeMs.get("testA")).isEqualTo(90);
     assertThat(metrics.tagTimeMs.get("testB")).isEqualTo(30);
@@ -143,10 +143,10 @@ public class WakeLockMetricsCollectorTest
     PowerManager.WakeLock wakeLockA = mPowerManager.newWakeLock(0, "testA");
     mCollector.newWakeLock(wakeLockA, 0, "testA");
 
-    assertThat(mCollector.getSnapshot(metrics)).isTrue();
+    assertThat(mCollector.getSnapshot(metrics, null)).isTrue();
 
     mCollector.disable();
-    assertThat(mCollector.getSnapshot(metrics)).isFalse();
+    assertThat(mCollector.getSnapshot(metrics, null)).isFalse();
 
     // Sanity check that nothing throws an exception or logs after disabling
     mCollector.release(wakeLockA, 0);
@@ -167,7 +167,7 @@ public class WakeLockMetricsCollectorTest
 
     WakeLockMetrics metricsA = new WakeLockMetrics(true);
 
-    assertThat(mCollector.getSnapshot(metricsA)).isTrue();
+    assertThat(mCollector.getSnapshot(metricsA, null)).isTrue();
     assertThat(metricsA.acquiredCount).isEqualTo(0);
     assertThat(metricsA.heldTimeMs).isEqualTo(0);
     assertThat(metricsA.tagTimeMs.size()).isEqualTo(0);
@@ -179,14 +179,14 @@ public class WakeLockMetricsCollectorTest
     mCollector.acquire(wakelock, 100);
 
     ShadowSystemClock.setUptimeMillis(51);
-    assertThat(mCollector.getSnapshot(metricsA)).isTrue();
+    assertThat(mCollector.getSnapshot(metricsA, null)).isTrue();
     assertThat(metricsA.acquiredCount).isEqualTo(1);
     assertThat(metricsA.heldTimeMs).isEqualTo(50);
     assertThat(metricsA.tagTimeMs.size()).isEqualTo(1);
     assertThat(metricsA.tagTimeMs.get("tag")).isEqualTo(50);
 
     ShadowSystemClock.setUptimeMillis(151);
-    assertThat(mCollector.getSnapshot(metricsA)).isTrue();
+    assertThat(mCollector.getSnapshot(metricsA, null)).isTrue();
     assertThat(metricsA.acquiredCount).isEqualTo(1);
     assertThat(metricsA.heldTimeMs).isEqualTo(100);
     assertThat(metricsA.tagTimeMs.size()).isEqualTo(1);
@@ -217,14 +217,14 @@ public class WakeLockMetricsCollectorTest
     mCollector.acquire(wakelock, 100);
 
     ShadowSystemClock.setUptimeMillis(51);
-    assertThat(mCollector.getSnapshot(metricsA)).isTrue();
+    assertThat(mCollector.getSnapshot(metricsA, null)).isTrue();
     assertThat(metricsA.acquiredCount).isEqualTo(1);
     assertThat(metricsA.heldTimeMs).isEqualTo(50);
     assertThat(metricsA.tagTimeMs.size()).isEqualTo(1);
     assertThat(metricsA.tagTimeMs.get("tag")).isEqualTo(50);
 
     ShadowSystemClock.setUptimeMillis(151);
-    assertThat(mCollector.getSnapshot(metricsA)).isTrue();
+    assertThat(mCollector.getSnapshot(metricsA, null)).isTrue();
     assertThat(metricsA.acquiredCount).isEqualTo(1);
     assertThat(metricsA.heldTimeMs).isEqualTo(100);
     assertThat(metricsA.tagTimeMs.size()).isEqualTo(1);
@@ -234,7 +234,7 @@ public class WakeLockMetricsCollectorTest
     wakelock.release();
     mCollector.release(wakelock, -1);
     WakeLockMetrics metricsB = new WakeLockMetrics(true);
-    assertThat(mCollector.getSnapshot(metricsB)).isTrue();
+    assertThat(mCollector.getSnapshot(metricsB, null)).isTrue();
     assertThat(metricsB).isEqualTo(metricsA);
   }
 
@@ -259,7 +259,7 @@ public class WakeLockMetricsCollectorTest
     mCollector.acquire(wakelock, -1);
 
     ShadowSystemClock.setUptimeMillis(151);
-    assertThat(mCollector.getSnapshot(snapshot)).isTrue();
+    assertThat(mCollector.getSnapshot(snapshot, null)).isTrue();
     assertThat(snapshot.acquiredCount).isEqualTo(1);
     assertThat(snapshot.heldTimeMs).isEqualTo(100);
 
@@ -267,7 +267,7 @@ public class WakeLockMetricsCollectorTest
     mCollector.release(wakelock, -1);
 
     ShadowSystemClock.setUptimeMillis(201);
-    assertThat(mCollector.getSnapshot(snapshot)).isTrue();
+    assertThat(mCollector.getSnapshot(snapshot, null)).isTrue();
     assertThat(snapshot.acquiredCount).isEqualTo(1);
     assertThat(snapshot.heldTimeMs).isEqualTo(100);
 
@@ -275,7 +275,7 @@ public class WakeLockMetricsCollectorTest
     mCollector.release(wakelock, -1);
 
     ShadowSystemClock.setUptimeMillis(251);
-    assertThat(mCollector.getSnapshot(snapshot)).isTrue();
+    assertThat(mCollector.getSnapshot(snapshot, null)).isTrue();
     assertThat(snapshot.acquiredCount).isEqualTo(1);
     assertThat(snapshot.heldTimeMs).isEqualTo(100);
   }

--- a/sample/src/main/java/com/facebook/battery/sample/MainActivity.java
+++ b/sample/src/main/java/com/facebook/battery/sample/MainActivity.java
@@ -97,7 +97,7 @@ public class MainActivity extends Activity {
   }
 
   private void updateContent() {
-    mCollector.getSnapshot(mMetrics);
+    mCollector.getSnapshot(mMetrics, this);
     String text = "Snapshot at " + SystemClock.elapsedRealtime() + ":\n\n" + mMetrics.toString();
     mContent.setText(text);
     Log.d("BatteryMetrics", text);


### PR DESCRIPTION
There are memory leaks in the library in DeviceBatteryMetricsCollector, and NetwokrMetricsCollector. Have fixed them in this PR by deregistering the broadcast receivers.